### PR TITLE
Feature/checker in docker container

### DIFF
--- a/contrib/checker-in-docker-container/README.md
+++ b/contrib/checker-in-docker-container/README.md
@@ -1,42 +1,56 @@
 # checker-as-service
 
-In current time it's concept. Development in progress.
+It's concept in current time. Development in progress.
 
 
 ## POST data format:
 
-- `t`: timeout
-- `m`: *mask* of host `[prefix, suffix]`, for example: `["10.22.", ".3"]`
+- `timeout`: timeout
+- `mask`: *mask* of host, for example: `"10.22.{}.3"`
+- `command`: command (`put` or `check`)
+- `checker`: `[host, port]`
+- `flags`: array of flags
+
+Flag format:
+
+Array of:
+- host substring
+- flag_id
+- flag (value)
 
 Example json:
 ```
 {
-  "t": 5,
-  "m": ["service", ""],
-  "1": { "run_test_NukYI5LV6h": "c01d5cab-ff8b-9771-e492-133050588587" },
-  "2": { "run_test_gGdVLcCjE7": "c01dad6c-4fc1-5787-4202-417f81383286" },
-  "3": { "run_test_c6hET9lPrR": "c01d2165-d46e-2535-e21d-2d1824383276" },
-  "4": { "run_test_WBJMDRa9yK": "c01d88cb-1821-43d6-6894-be3494757323" },
-  "5": { "run_test_Rtkd6qWjRE": "c01dd670-43d7-458f-7aa7-731910962441" },
-  "6": { "run_test_PujksbRcy1": "c01dbcea-2ca1-6a7b-4680-be7b60448216" },
-  "7": { "run_test_NiuczwyrlQ": "c01d93be-b44a-bbab-5005-42cb27909855" },
-  "8": { "run_test_5xGaMQ5TbX": "c01d660d-b45e-18ef-dd60-f1c873170438" },
-  "9": { "run_test_wn9JKMp7Eb": "c01dc8cc-55cb-7a52-105d-9be852903760" },
-  "10": { "run_test_YFxnmBJmgk": "c01de2d2-27dc-13d7-4043-244593700652" },
-  "11": { "run_test_erslvY4yHr": "c01d2cad-2b0a-98be-14c3-35fb78483134" },
-  "12": { "run_test_jb9CC5zua1": "c01db8e9-4456-96d4-9985-024e13954292" },
-  "13": { "run_test_bfDmtjEQ7i": "c01dfdee-829c-a3dd-83d5-4bbe45901963" },
-  "14": { "run_test_ejJQg8MTZa": "c01d90f1-2d3c-ca2c-5771-511362925427" },
-  "15": { "run_test_4Rhr64IRQV": "c01dc0a7-bc71-5841-3904-0c8d20063884" },
-  "16": { "run_test_2gaRgY79ms": "c01d7d2e-73c3-07ea-3567-10d544440980" },
-  "17": { "run_test_2YiD8vUs49": "c01da469-f8c9-c10a-c506-7a6e24401093" },
-  "18": { "run_test_QyxcZW4XYt": "c01db2bd-2123-86a6-fef7-775b50072744" },
-  "19": { "run_test_cWe4OHHRCs": "c01d0e4a-0b0c-838d-6f62-e04978444387" },
-  "20": { "run_test_JMw40RIWgW": "c01dbaf1-ed2e-a2d8-11a9-7b7c41033202" },
-  "21": { "run_test_Xpx7sHqpdi": "c01dc2e2-cac9-5d1f-a30f-90c851543738" },
-  "22": { "run_test_Wpp7B2TiNV": "c01dcc95-1985-4ba5-cb84-3df899074580" },
-  "23": { "run_test_ngfEvgstwm": "c01dbf55-30ee-b617-fca3-db3081178820" },
-  "25": { "run_test_jUtoZRRule": "c01dc916-4d1f-1da5-067c-122c96031782" }
+  "timeout": 5,
+  "mask": "service{}",
+  "command": "put",
+  "checker": ["checker-in-docker", 4109],
+  "flags": [
+      ["1", "run_test_NukYI5LV6h", "c01d5cab-ff8b-9771-e492-133050588587"],
+      ["2", "run_test_gGdVLcCjE7", "c01dad6c-4fc1-5787-4202-417f81383286"],
+      ["3", "run_test_c6hET9lPrR", "c01d2165-d46e-2535-e21d-2d1824383276"],
+      ["4", "run_test_WBJMDRa9yK", "c01d88cb-1821-43d6-6894-be3494757323"],
+      ["5", "run_test_Rtkd6qWjRE", "c01dd670-43d7-458f-7aa7-731910962441"],
+      ["6", "run_test_PujksbRcy1", "c01dbcea-2ca1-6a7b-4680-be7b60448216"],
+      ["7", "run_test_NiuczwyrlQ", "c01d93be-b44a-bbab-5005-42cb27909855"],
+      ["8", "run_test_5xGaMQ5TbX", "c01d660d-b45e-18ef-dd60-f1c873170438"],
+      ["9", "run_test_wn9JKMp7Eb", "c01dc8cc-55cb-7a52-105d-9be852903760"],
+      ["10", "run_test_YFxnmBJmgk", "c01de2d2-27dc-13d7-4043-244593700652"],
+      ["11", "run_test_erslvY4yHr", "c01d2cad-2b0a-98be-14c3-35fb78483134"],
+      ["12", "run_test_jb9CC5zua1", "c01db8e9-4456-96d4-9985-024e13954292"],
+      ["13", "run_test_bfDmtjEQ7i", "c01dfdee-829c-a3dd-83d5-4bbe45901963"],
+      ["14", "run_test_ejJQg8MTZa", "c01d90f1-2d3c-ca2c-5771-511362925427"],
+      ["15", "run_test_4Rhr64IRQV", "c01dc0a7-bc71-5841-3904-0c8d20063884"],
+      ["16", "run_test_2gaRgY79ms", "c01d7d2e-73c3-07ea-3567-10d544440980"],
+      ["17", "run_test_2YiD8vUs49", "c01da469-f8c9-c10a-c506-7a6e24401093"],
+      ["18", "run_test_QyxcZW4XYt", "c01db2bd-2123-86a6-fef7-775b50072744"],
+      ["19", "run_test_cWe4OHHRCs", "c01d0e4a-0b0c-838d-6f62-e04978444387"],
+      ["20", "run_test_JMw40RIWgW", "c01dbaf1-ed2e-a2d8-11a9-7b7c41033202"],
+      ["21", "run_test_Xpx7sHqpdi", "c01dc2e2-cac9-5d1f-a30f-90c851543738"],
+      ["22", "run_test_Wpp7B2TiNV", "c01dcc95-1985-4ba5-cb84-3df899074580"],
+      ["23", "run_test_ngfEvgstwm", "c01dbf55-30ee-b617-fca3-db3081178820"],
+      ["25", "run_test_jUtoZRRule", "c01dc916-4d1f-1da5-067c-122c96031782"]
+  ]
 }
 ```
 
@@ -55,41 +69,41 @@ for example commands run checkers:
 
 ```
 {
-  "1": "u",
-  "2": "u",
-  "3": "u",
-  "4": "d",
-  "5": "u",
-  "6": "c",
-  "7": "u",
-  "8": "m",
-  "9": "u",
-  "10": "u",
-  "11": "u",
-  "12": "u",
-  "13": "u",
-  "14": "u",
-  "15": "u",
-  "16": "u",
-  "17": "u",
-  "18": "u",
-  "19": "u",
-  "20": "u",
-  "21": "u",
-  "22": "u",
-  "23": "u",
-  "25": "u"
+  "1": 101,
+  "2": 101,
+  "3": 101,
+  "4": 102,
+  "5": 101,
+  "6": "103",
+  "7": 101,
+  "8": 104,
+  "9": 101,
+  "10": 101,
+  "11": 101,
+  "12": 101,
+  "13": 101,
+  "14": 101,
+  "15": 101,
+  "16": 101,
+  "17": 101,
+  "18": 101,
+  "19": 101,
+  "20": 101,
+  "21": 101,
+  "22": 101,
+  "23": 101,
+  "25": 101
 }
 ```
 
 About states:
 
-- `"u"` (101)  up - the flag putting/checking into the service is successful
-- `"d"` (102)  down - service is not available (maybe blocked port or service is down)
-- `"c"` (103)  corrupt - service is available (available tcp connection) but it's impossible to put/get the flag
-- `"m"` (104)  mumble - checker-script worked long time than allowed (this state will be set by ctf01d)
-- `"s"` (any)  shit - problems in checker (this state will be set by ctf01d), for checker developers
-- `"x"` - problems with checker-as-service (notify about inside problems)
+- 101 - up - the flag putting/checking into the service is successful
+- 102 - down - service is not available (maybe blocked port or service is down)
+- 103 - corrupt - service is available (available tcp connection) but it's impossible to put/get the flag
+- 104 - mumble - checker-script worked long time than allowed (this state will be set by ctf01d)
+- (any) - shit - problems in checker (this state will be set by ctf01d), for checker developers
+- 500? - problems with checker-as-service (notify about inside problems)
 
 So:
 

--- a/contrib/checker-in-docker-container/README.md
+++ b/contrib/checker-in-docker-container/README.md
@@ -23,8 +23,8 @@ Example json:
 {
   "timeout": 5,
   "mask": "service{}",
-  "command": "put",
-  "checker": ["checker-in-docker", 4109],
+  "command": "check",
+  "checker": ["localhost", 4109],
   "flags": [
       ["1", "run_test_NukYI5LV6h", "c01d5cab-ff8b-9771-e492-133050588587"],
       ["2", "run_test_gGdVLcCjE7", "c01dad6c-4fc1-5787-4202-417f81383286"],
@@ -72,11 +72,11 @@ for example commands run checkers:
   "1": 101,
   "2": 101,
   "3": 101,
-  "4": 102,
+  "4": 104,
   "5": 101,
-  "6": "103",
+  "6": 102,
   "7": 101,
-  "8": 104,
+  "8": 103,
   "9": 101,
   "10": 101,
   "11": 101,
@@ -99,9 +99,9 @@ for example commands run checkers:
 About states:
 
 - 101 - up - the flag putting/checking into the service is successful
-- 102 - down - service is not available (maybe blocked port or service is down)
-- 103 - corrupt - service is available (available tcp connection) but it's impossible to put/get the flag
-- 104 - mumble - checker-script worked long time than allowed (this state will be set by ctf01d)
+- 102 - corrupt - service is available (available tcp connection) but it's impossible to put/get the flag
+- 103 - mumble - checker-script worked long time than allowed (this state will be set by ctf01d)
+- 104 - down - service is not available (maybe blocked port or service is down)
 - (any) - shit - problems in checker (this state will be set by ctf01d), for checker developers
 - 500? - problems with checker-as-service (notify about inside problems)
 

--- a/contrib/checker-in-docker-container/docker-compose.yml
+++ b/contrib/checker-in-docker-container/docker-compose.yml
@@ -2,13 +2,23 @@ version: '3'
 
 services:
 
-  run_example_checkers:
-    image: python:latest
+#  run_example_checkers:
+#    image: python:latest
+#    volumes:
+#      - "./examples/run_example_checker.py:/root/run.py"
+#      - "./examples/example_checker.py:/root/example_checker.py"
+#    restart: always
+#    command: "sh -c 'cd /root/ && python3 --version && python3 -u run.py'"
+#    networks:
+#      - ctf01d_checker_as_service
+
+  checker-in-docker:
+    build: poc/checker-in-docker
     volumes:
-      - "./examples/run_example_checker.py:/root/run.py"
-      - "./examples/example_checker.py:/root/example_checker.py"
+      - "./poc/checker-in-docker/checker.py:/app/checker.py"
     restart: always
-    command: "sh -c 'cd /root/ && python3 --version && python3 -u run.py'"
+    ports:
+      - 4109:4109
     networks:
       - ctf01d_checker_as_service
 

--- a/contrib/checker-in-docker-container/poc/checker-in-docker/Dockerfile
+++ b/contrib/checker-in-docker-container/poc/checker-in-docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# копируем только requirements, сам checker будет через volume
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:4109", "checker:app"]

--- a/contrib/checker-in-docker-container/poc/checker-in-docker/README.md
+++ b/contrib/checker-in-docker-container/poc/checker-in-docker/README.md
@@ -1,0 +1,11 @@
+```bash
+curl -X POST http://localhost:4109/put \
+  -H "Content-Type: application/json" \
+  -d '["service1", "id1", "flag1"]'
+```
+
+```bash
+curl -X POST http://localhost:4109/check \
+  -H "Content-Type: application/json" \
+  -d '["service1", "id1", "flag1"]'
+```

--- a/contrib/checker-in-docker-container/poc/checker-in-docker/checker.py
+++ b/contrib/checker-in-docker-container/poc/checker-in-docker/checker.py
@@ -1,34 +1,61 @@
-import socket
 import errno
+import logging
+import socket
 
 from flask import Flask, request, jsonify
 
 
 PORT = 4101
 
+logging.basicConfig(
+    format="%(asctime)s [name] <thr-%(thread)d> %(levelname)s: %(message)s", level=logging.DEBUG
+)
+logger = logging.getLogger(__name__)
+
 
 # put-get flag to service success
 def service_up():
-    print("[service is worked] - 101")
+    logger.info("[service is worked] - 101")
     return jsonify(101)
 
 # service is available (available tcp connect) but protocol wrong could not put/get flag
 def service_corrupt():
-    print("[service is corrupt] - 102")
+    logger.info("[service is corrupt] - 102")
     return jsonify(102)
 
 # waited time (for example: 5 sec) but service did not have time to reply
 def service_mumble():
-    print("[service is mumble] - 103")
+    logger.info("[service is mumble] - 103")
     return jsonify(103)
 
 # service is not available (maybe blocked port or service is down)
 def service_down():
-    print("[service is down] - 104")
+    logger.info("[service is down] - 104")
     return jsonify(104)
 
 
 app = Flask(__name__)
+
+
+@app.before_request
+def log_request():
+    if request.method != 'POST' or request.path not in ('/put', '/check'):
+        return
+    logger.info('Request %s %s: data=%r', request.method, request.path, request.json)
+
+
+@app.after_request
+def log_response(response):
+    if request.method != 'POST' or request.path not in ('/put', '/check'):
+        return response
+    logger.info(
+        'Response %s %s: status=%d body=%s',
+        request.method,
+        request.path,
+        response.status_code,
+        response.get_data(as_text=True),
+    )
+    return response
 
 
 @app.route('/put', methods=['POST'])
@@ -54,10 +81,10 @@ def put():
         if serr.errno == errno.ECONNREFUSED:
             return service_down()
         else:
-            print(serr)
+            logger.exception('Socket error on put: %s', serr)
             return service_corrupt()
     except Exception as e:
-        print(e)
+        logger.exception('Unhandled exception on put: %s', e)
         return service_corrupt()
     return service_up()
 
@@ -89,10 +116,10 @@ def check():
         if serr.errno == errno.ECONNREFUSED:
             return service_down()
         else:
-            print(serr)
+            logger.exception('Socket error on check: %s', serr)
             return service_corrupt()
     except Exception as e:
-        print(e)
+        logger.exception('Unhandled exception on check: %s', e)
         return service_corrupt()
 
     if flag != flag2:

--- a/contrib/checker-in-docker-container/poc/checker-in-docker/checker.py
+++ b/contrib/checker-in-docker-container/poc/checker-in-docker/checker.py
@@ -1,0 +1,101 @@
+import socket
+import errno
+
+from flask import Flask, request, jsonify
+
+
+PORT = 4101
+
+
+# put-get flag to service success
+def service_up():
+    print("[service is worked] - 101")
+    return jsonify(101)
+
+# service is available (available tcp connect) but protocol wrong could not put/get flag
+def service_corrupt():
+    print("[service is corrupt] - 102")
+    return jsonify(102)
+
+# waited time (for example: 5 sec) but service did not have time to reply
+def service_mumble():
+    print("[service is mumble] - 103")
+    return jsonify(103)
+
+# service is not available (maybe blocked port or service is down)
+def service_down():
+    print("[service is down] - 104")
+    return jsonify(104)
+
+
+app = Flask(__name__)
+
+
+@app.route('/put', methods=['POST'])
+def put():
+    host, f_id, flag = request.json
+    try:
+        # print("try connect " + host + ":" + str(port))
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect((host, PORT))
+        _ = s.recv(1024).decode("utf-8")
+        # print(result)
+        s.send("put\n".encode())
+        _ = s.recv(1024).decode("utf-8")
+        s.send(str(f_id + "\n").encode())
+        _ = s.recv(1024).decode("utf-8")
+        s.send(str(flag + "\n").encode())
+        _ = s.recv(1024).decode("utf-8")
+        s.close()
+    except socket.timeout:
+        return service_mumble()
+    except socket.error as serr:
+        if serr.errno == errno.ECONNREFUSED:
+            return service_down()
+        else:
+            print(serr)
+            return service_corrupt()
+    except Exception as e:
+        print(e)
+        return service_corrupt()
+    return service_up()
+
+
+@app.route('/check', methods=['POST'])
+def check():
+    host, f_id, flag = request.json
+    try:
+        # print("try connect " + host + ":" + str(port))
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(10)
+        s.connect((host, PORT))
+        result = s.recv(1024).decode("utf-8")
+        # print(result)
+        s.send("get\n".encode())
+        result = s.recv(1024).decode("utf-8")
+        s.send(str(f_id + "\n").encode())
+        result = s.recv(1024).decode("utf-8")
+        flag2 = result.strip()
+        flag2 = flag2.split("FOUND FLAG: ")
+        if len(flag2) == 2:
+            flag2 = flag2[1]
+        else:
+            flag2 = ''
+        s.close()
+    except socket.timeout:
+        return service_down()
+    except socket.error as serr:
+        if serr.errno == errno.ECONNREFUSED:
+            return service_down()
+        else:
+            print(serr)
+            return service_corrupt()
+    except Exception as e:
+        print(e)
+        return service_corrupt()
+
+    if flag != flag2:
+        return service_corrupt()
+
+    return service_up()

--- a/contrib/checker-in-docker-container/poc/checker-in-docker/requirements.txt
+++ b/contrib/checker-in-docker-container/poc/checker-in-docker/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.1.3
+gunicorn==25.3.0

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/app.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/app.py
@@ -10,6 +10,7 @@ from constants import MASK_KEY
 from constants import COMMAND_KEY
 from constants import CHECKER_KEY
 from constants import FLAGS_KEY
+from flag_forwarder import forward_flags
 
 logging.basicConfig(
     format="%(asctime)s [name] <thr-%(thread)d> %(levelname)s: %(message)s", level=logging.DEBUG
@@ -23,6 +24,10 @@ def forward(data: dict) -> dict:
     command = data.get(COMMAND_KEY)
     flags = data.get(FLAGS_KEY, [])
     checker_host, checker_port = data.get(CHECKER_KEY)
+
+    if command not in ('put', 'check'):
+        raise NotImplementedError(f'Command {command} is not implemented')
+
     logger.info(
         'Got such data: timeout=%r, mask=%r, command=%r, len(flags)=%d, checker_host=%r, checker_port=%d',
         timeout,
@@ -31,6 +36,14 @@ def forward(data: dict) -> dict:
         len(flags),
         checker_host,
         checker_port,
+    )
+    return forward_flags(
+        timeout=timeout,
+        mask=mask,
+        command=command,
+        checker_host=checker_host,
+        checker_port=checker_port,
+        flags=flags,
     )
 
 
@@ -45,8 +58,8 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                 data.append(chunk)
             data = b''.join(data)
             data = json.loads(data)
-            forward(data)
-            self.request.sendall(b'gotcha\n')
+            result = forward(data)
+            self.request.sendall(json.dumps(result, sort_keys=True).encode('utf-8'))
         except Exception as exc:
             logger.exception('Unhandled exception')
             error_data = {'error': repr(exc)}

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/app.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/app.py
@@ -1,0 +1,64 @@
+import json
+import logging
+import socketserver
+
+from configs import DEFAULT_TIMEOUT
+from configs import HOST
+from configs import PORT
+from constants import TIMEOUT_KEY
+from constants import MASK_KEY
+from constants import COMMAND_KEY
+from constants import CHECKER_KEY
+from constants import FLAGS_KEY
+
+logging.basicConfig(
+    format="%(asctime)s [name] <thr-%(thread)d> %(levelname)s: %(message)s", level=logging.DEBUG
+)
+logger = logging.getLogger(__name__)
+
+
+def forward(data: dict) -> dict:
+    timeout = data.get(TIMEOUT_KEY, DEFAULT_TIMEOUT)
+    mask = data.get(MASK_KEY, '')
+    command = data.get(COMMAND_KEY)
+    flags = data.get(FLAGS_KEY, [])
+    checker_host, checker_port = data.get(CHECKER_KEY)
+    logger.info(
+        'Got such data: timeout=%r, mask=%r, command=%r, len(flags)=%d, checker_host=%r, checker_port=%d',
+        timeout,
+        mask,
+        command,
+        len(flags),
+        checker_host,
+        checker_port,
+    )
+
+
+class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            data = []
+            while True:
+                chunk = self.request.recv(1024)
+                if not chunk.strip():
+                    break
+                data.append(chunk)
+            data = b''.join(data)
+            data = json.loads(data)
+            forward(data)
+            self.request.sendall(b'gotcha\n')
+        except Exception as exc:
+            logger.exception('Unhandled exception')
+            error_data = {'error': repr(exc)}
+            self.request.sendall(json.dumps(error_data).encode('utf-8'))
+
+
+class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+if __name__ == '__main__':
+    server = ThreadedTCPServer((HOST, PORT), ThreadedTCPRequestHandler)
+    with server:
+        logger.info('Socket server for forwarding flags is started (%r, %d)', HOST, PORT)
+        server.serve_forever()

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/configs.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/configs.py
@@ -2,3 +2,4 @@ HOST = 'localhost'
 PORT = 4009
 
 DEFAULT_TIMEOUT = 5
+MAX_WORKERS = 32

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/configs.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/configs.py
@@ -1,0 +1,4 @@
+HOST = 'localhost'
+PORT = 4009
+
+DEFAULT_TIMEOUT = 5

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/constants.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/constants.py
@@ -1,5 +1,8 @@
 TIMEOUT_KEY = 'timeout'
 MASK_KEY = 'mask'
-COMMAND_KEY = 'ccommand'
+COMMAND_KEY = 'command'
 CHECKER_KEY = 'checker'
 FLAGS_KEY = 'flags'
+
+CHECKER_SERVICE_DOWN = 103
+CHECKER_SERVICE_ERROR = 500

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/constants.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/constants.py
@@ -1,0 +1,5 @@
+TIMEOUT_KEY = 'timeout'
+MASK_KEY = 'mask'
+COMMAND_KEY = 'ccommand'
+CHECKER_KEY = 'checker'
+FLAGS_KEY = 'flags'

--- a/contrib/checker-in-docker-container/poc/checker-redirecter/flag_forwarder.py
+++ b/contrib/checker-in-docker-container/poc/checker-redirecter/flag_forwarder.py
@@ -1,0 +1,118 @@
+import json
+import logging
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from urllib.error import URLError
+from urllib.request import Request
+from urllib.request import urlopen
+
+from configs import MAX_WORKERS
+from constants import CHECKER_SERVICE_DOWN
+from constants import CHECKER_SERVICE_ERROR
+
+logger = logging.getLogger(__name__)
+
+
+def build_service_host(mask: str, host_id: str) -> str:
+    return mask.format(host_id)
+
+
+def _call_checker(
+    checker_host: str,
+    checker_port: int,
+    command: str,
+    service_host: str,
+    flag_id: str,
+    flag_value: str,
+    timeout: float,
+) -> int | str:
+    url = f'http://{checker_host}:{checker_port}/{command}'
+    payload = json.dumps([service_host, flag_id, flag_value]).encode('utf-8')
+    request = Request(
+        url,
+        data=payload,
+        headers={'Content-Type': 'application/json'},
+        method='POST',
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode('utf-8'))
+    except (TimeoutError, socket.timeout):
+        logger.warning('Checker request timed out: %s', url)
+        return CHECKER_SERVICE_DOWN
+    except URLError as e:
+        if isinstance(e.reason, (TimeoutError, socket.timeout)):
+            logger.warning('Checker request timed out: %s', url)
+            return CHECKER_SERVICE_DOWN
+        raise
+
+
+def _process_flag(
+    host_id: str,
+    flag_id: str,
+    flag_value: str,
+    mask: str,
+    command: str,
+    checker_host: str,
+    checker_port: int,
+    timeout: float,
+) -> tuple[str, int | str]:
+    try:
+        service_host = build_service_host(mask, host_id)
+        status = _call_checker(
+            checker_host,
+            checker_port,
+            command,
+            service_host,
+            flag_id,
+            flag_value,
+            timeout,
+        )
+
+    except Exception:
+        logger.exception('Failed to process flag for host_id=%r', host_id)
+        return host_id, CHECKER_SERVICE_ERROR
+
+    logger.debug(
+        'Flag for host_id=%r (service=%r): status=%r',
+        host_id,
+        service_host,
+        status,
+    )
+    return host_id, status
+
+def forward_flags(
+    timeout: float,
+    mask: str,
+    command: str,
+    checker_host: str,
+    checker_port: int,
+    flags: list,
+) -> dict[str, int | str]:
+    if not flags:
+        return {}
+
+    max_workers = min(len(flags), MAX_WORKERS)
+    results: dict[str, int | str] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                _process_flag,
+                host_id,
+                flag_id,
+                flag_value,
+                mask,
+                command,
+                checker_host,
+                checker_port,
+                timeout,
+            )
+            for host_id, flag_id, flag_value in flags
+        ]
+        for future in as_completed(futures):
+            host_id, status = future.result()
+            results[host_id] = status
+
+    return results


### PR DESCRIPTION
По изменению формата:

- ключи `t` / `m` изменил на более читаемые timeout и mask. не вижу смысла экономить десяток байтов
- изменил формат маски на более удобный для python и читаемый
- добавил команду check/put
- добавил `checker` (host и port чтобы знать куда слать флаги)
- флаги вынес в `flags`
- формат флагов теперь: список списков team substring, flag id, flag value

- в выходынх данных решил что пусть будут коды как они были до этого (101, 102, 103, и т.д.)
- там в кодах ошибки была путаница, вернул маппинг как он был до этого
- 500 для ошибок можно поменять на другой (например, на 105 или 106, обсуждаемо)

Что еще нужно сделать:
- добавить в логгер чекеров контекста, т.к. из-за параллельного вызова не понятно какой лог к какому вызову относится
- обернуть checker-redirecter в докер / докер компоуз
- ...
