### PR TITLE
prevent duplicate flag submissions

### DIFF
--- a/src/ctf01d_http_server.cpp
+++ b/src/ctf01d_http_server.cpp
@@ -354,16 +354,17 @@ int Ctf01dHttpServer::httpApiV1Flag(HttpRequest* req, HttpResponse* resp) {
         return 403;
     }
 
-    if (m_pEmployDatabase->isAlreadyStole(flag, sTeamId)) {
-        static const std::string sErrorMsg = "Error(-170): flag already stolen by your";
+    // TODO light update scoreboard
+    // Atomic dedup: UNIQUE INDEX on flags_stolen + INSERT OR IGNORE.
+    // The DB layer is the single source of truth — no separate pre-check needed.
+    std::optional<int> oPoints = m_pConfig->scoreboard()->incrementAttackScore(flag, sTeamId);
+    if (!oPoints.has_value()) {
+        static const std::string sErrorMsg = "Error(-170): flag already stolen by your team";
         WsjcppLog::err(TAG, sErrorMsg + ". Received flag {" + sFlag + "} from {" + sTeamId + "}" + sRequestIP_MsgSuffix);
         resp->String(sErrorMsg);
         return 403;
     }
-
-    // TODO light update scoreboard
-    int nPoints = m_pConfig->scoreboard()->incrementAttackScore(flag, sTeamId);
-    std::string sPoints = std::to_string(double(nPoints) / 10.0);
+    std::string sPoints = std::to_string(double(oPoints.value()) / 10.0);
 
     std::string sResponse = "Accepted: Received flag {" + sFlag + "} from {" + sTeamId + "} (Accepted + " + sPoints + ")";
     WsjcppLog::ok(TAG, sResponse + sRequestIP_MsgSuffix);

--- a/src/employees/employ_database.cpp
+++ b/src/employees/employ_database.cpp
@@ -146,6 +146,19 @@ bool Ctf01dDatabaseFile::executeQuery(std::string sSqlInsert) {
     return true;
 }
 
+// Returns true iff a row was actually inserted (UNIQUE conflict -> false).
+// Caller is responsible for using INSERT OR IGNORE in the query.
+bool Ctf01dDatabaseFile::insertOrIgnore(std::string sSqlInsertOrIgnore) {
+    copyDatabaseToBackup();
+    char *zErrMsg = 0;
+    int nRet = sqlite3_exec(m_pDatabaseFile, sSqlInsertOrIgnore.c_str(), 0, 0, &zErrMsg);
+    if (nRet != SQLITE_OK) {
+        WsjcppLog::throw_err(TAG, "Problem with insert: " + std::string(zErrMsg) + "\n SQL-query: " + sSqlInsertOrIgnore);
+        return false;
+    }
+    return sqlite3_changes(m_pDatabaseFile) > 0;
+}
+
 int Ctf01dDatabaseFile::selectSumOrCount(std::string sSqlSelectCount) {
     copyDatabaseToBackup();
     sqlite3_stmt* pQuery = nullptr;
@@ -314,6 +327,12 @@ bool EmployDatabase::init() {
     if (!m_pFlagsStolen->open()) {
         return false;
     }
+    if (!m_pFlagsStolen->executeQuery(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_flags_stolen "
+        "ON flags_stolen(serviceid, thief_teamid, flag);"
+    )) {
+        return false;
+    }
 
     m_pFlagsLive = new Ctf01dDatabaseFile("flags_live.db",
         "CREATE TABLE IF NOT EXISTS flags_live ( "
@@ -327,6 +346,12 @@ bool EmployDatabase::init() {
         ");"
     );
     if (!m_pFlagsLive->open()) {
+        return false;
+    }
+    if (!m_pFlagsLive->executeQuery(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_flags_live_flag "
+        "ON flags_live(flag);"
+    )) {
         return false;
     }
     return true;
@@ -493,11 +518,11 @@ std::pair<std::string, long> EmployDatabase::getFirstbloodFromStolenFlagsForServ
     return pairRet;
 }
 
-void EmployDatabase::insertToFlagsStolen(Ctf01dFlag flag, std::string sTeamId, int nPoints, long nDateAction, int nVictimPlaceInScoreBoard, int nThiefPlaceInScoreboard) {
+bool EmployDatabase::insertToFlagsStolen(Ctf01dFlag flag, std::string sTeamId, int nPoints, long nDateAction, int nVictimPlaceInScoreBoard, int nThiefPlaceInScoreboard) {
     // TODO
     // nVictimPlaceInScoreBoard
     // nThiefPlaceInScoreboard
-    std::string sQuery = "INSERT INTO flags_stolen(serviceid, teamid, thief_teamid, flag_id, flag,"
+    std::string sQuery = "INSERT OR IGNORE INTO flags_stolen(serviceid, teamid, thief_teamid, flag_id, flag,"
         "   date_start, date_end, date_action, flag_cost) VALUES("
         "'" + flag.getServiceId() + "', "
         + "'" + flag.getTeamId() + "', "
@@ -510,22 +535,9 @@ void EmployDatabase::insertToFlagsStolen(Ctf01dFlag flag, std::string sTeamId, i
         + std::to_string(nPoints) + " "
         + ");";
 
-    if (!m_pFlagsStolen->executeQuery(sQuery)) {
-        WsjcppLog::err(TAG, "Error insert insertToFlagsDefence");
-    }
+    return m_pFlagsStolen->insertOrIgnore(sQuery);
 }
 
-
-bool EmployDatabase::isAlreadyStole(Ctf01dFlag flag, std::string sTeamId) {
-    int nRet = m_pFlagsStolen->selectSumOrCount(
-        "SELECT COUNT(*) as cnt FROM flags_stolen "
-            " WHERE serviceid = '" + flag.getServiceId() + "' "
-            "   AND thief_teamid = '" + sTeamId + "'"
-            "   AND flag_id = '" + flag.getId() + "'"
-            "   AND flag = '" + flag.getValue() + "'"
-    );
-    return nRet > 0;
-}
 
 bool EmployDatabase::isSomebodyStole(Ctf01dFlag flag) {
     int nRet = m_pFlagsStolen->selectSumOrCount(

--- a/src/employees/employ_database.h
+++ b/src/employees/employ_database.h
@@ -60,6 +60,7 @@ class Ctf01dDatabaseFile {
         ~Ctf01dDatabaseFile();
         bool open();
         bool executeQuery(std::string sSqlInsert);
+        bool insertOrIgnore(std::string sSqlInsertOrIgnore);
         int selectSumOrCount(std::string sSqlSelectCount);
         bool selectRows(std::string sSqlSelectRows, Ctf01dDatabaseSelectRows &selectRows);
 
@@ -104,8 +105,7 @@ class EmployDatabase : public WsjcppEmployBase {
         int sumPointsOfFlagsStollen(std::string sTeamId, std::string sServiceId);
         int numberOfStolenFlagsForService(std::string sServiceId);
         std::pair<std::string, long> getFirstbloodFromStolenFlagsForService(std::string sServiceId);
-        void insertToFlagsStolen(Ctf01dFlag flag, std::string sTeamId, int nPoints, long nDateAction, int nVictimPlaceInScoreBoard, int nThiefPlaceInScoreboard);
-        bool isAlreadyStole(Ctf01dFlag flag, std::string sTeamId);
+        bool insertToFlagsStolen(Ctf01dFlag flag, std::string sTeamId, int nPoints, long nDateAction, int nVictimPlaceInScoreBoard, int nThiefPlaceInScoreboard);
         bool isSomebodyStole(Ctf01dFlag flag);
 
         // flags live

--- a/src/scoreboard/ctf01d_scoreboard.cpp
+++ b/src/scoreboard/ctf01d_scoreboard.cpp
@@ -299,7 +299,7 @@ void Ctf01dScoreboard::initStateFromStorage() {
     }
 }
 
-int Ctf01dScoreboard::incrementAttackScore(const Ctf01dFlag &flag, const std::string &sTeamId) {
+std::optional<int> Ctf01dScoreboard::incrementAttackScore(const Ctf01dFlag &flag, const std::string &sTeamId) {
     std::lock_guard<std::mutex> lock(m_mutexJson);
     std::string sServiceId = flag.getServiceId();
 
@@ -333,7 +333,10 @@ int Ctf01dScoreboard::incrementAttackScore(const Ctf01dFlag &flag, const std::st
         // WsjcppLog::info(TAG, "nMotivation " + std::to_string(nMotivation));
         // WsjcppLog::info(TAG, "nFlagPoints " + std::to_string(nFlagPoints));
 
-        m_pDatabase->insertToFlagsStolen(flag, sTeamId, nFlagPoints, nDateAction, nVictimPlaceInScoreBoard, nThiefPlaceInScoreboard);
+        if (!m_pDatabase->insertToFlagsStolen(flag, sTeamId, nFlagPoints, nDateAction, nVictimPlaceInScoreBoard, nThiefPlaceInScoreboard)) {
+            WsjcppLog::warn(TAG, "Flag already stolen by team " + sTeamId + ": " + flag.getValue());
+            return std::nullopt;
+        }
         pRow->incrementAttack(sServiceId, nFlagPoints);
         pRow->updatePoints();
         m_jsonScoreboard["scoreboard"][sTeamId]["ts_sta"][sServiceId]["att"] = pRow->getAttackFlags(sServiceId);

--- a/src/scoreboard/ctf01d_scoreboard.h
+++ b/src/scoreboard/ctf01d_scoreboard.h
@@ -38,6 +38,7 @@
 #include <employ_flags.h>
 #include <employ_scoreboard.h>
 #include <employ_database.h>
+#include <optional>
 #include <string>
 #include <json.hpp>
 
@@ -58,7 +59,10 @@ class Ctf01dScoreboard {
         void incrementTries(const std::string &sTeamId);
         void initStateFromStorage();
 
-        int incrementAttackScore(const Ctf01dFlag &flag, const std::string &sTeamId);
+        // Returns nFlagPoints if the flag was actually credited (DB UNIQUE accepted the row).
+        // Returns std::nullopt if this flag was already stolen by the same team
+        // (race with a concurrent submission, caught by UNIQUE INDEX).
+        std::optional<int> incrementAttackScore(const Ctf01dFlag &flag, const std::string &sTeamId);
         void incrementDefenceScore(const Ctf01dFlag &flag);
         void incrementFlagsPuttedAndServiceUp(const Ctf01dFlag &flag);
         void insertFlagPutFail(const Ctf01dFlag &flag, const std::string &sServiceStatus, const std::string &sDescrStatus);


### PR DESCRIPTION
add unique indexes on flags_stolen and flags_live tables to prevent duplicate entries at the database level. Use INSERT OR IGNORE for stolen flags and return 403 when a flag has already been submitted.