### PR TITLE
remove flag live time #87

### DIFF
--- a/src/ctf01d/employees/employ_config.cpp
+++ b/src/ctf01d/employees/employ_config.cpp
@@ -163,8 +163,7 @@ bool EmployConfig::applyConfig() {
         m_nGameStartUTCInSec,
         m_nGameEndUTCInSec,
         m_nGameCoffeeBreakStartUTCInSec,
-        m_nGameCoffeeBreakEndUTCInSec,
-        m_nFlagTimeliveInMin*60
+        m_nGameCoffeeBreakEndUTCInSec
     );
 
     m_bAppliedConfig = true;

--- a/src/ctf01d/objects/ctf01d_scoreboard.cpp
+++ b/src/ctf01d/objects/ctf01d_scoreboard.cpp
@@ -49,8 +49,7 @@ Ctf01dScoreboard::Ctf01dScoreboard(
   int nGameStartInSec,
   int nGameEndInSec,
   int nGameCoffeeBreakStartInSec,
-  int nGameCoffeeBreakEndInSec,
-  int nFlagTimeLiveInSec
+  int nGameCoffeeBreakEndInSec
 ) {
   TAG = "Ctf01dScoreboard";
   EmployConfig *pEmployConfig = findWsjcppEmploy<EmployConfig>();
@@ -66,7 +65,6 @@ Ctf01dScoreboard::Ctf01dScoreboard(
   m_nGameEndInSec = nGameEndInSec;
   m_nGameCoffeeBreakStartInSec = nGameCoffeeBreakStartInSec;
   m_nGameCoffeeBreakEndInSec = nGameCoffeeBreakEndInSec;
-  m_nFlagTimeLiveInSec = nFlagTimeLiveInSec;
   m_nAllDefenseFlags = 0;
   m_nAllTriesActivities = 0;
   m_nCostDefenseFlagInPoints10 = 10;
@@ -507,7 +505,7 @@ void Ctf01dScoreboard::updateServicesStatistics() {
 std::vector<Ctf01dFlag> Ctf01dScoreboard::outdatedFlagsLive(const std::string &sTeamId, const std::string &sServiceId) {
   std::lock_guard<std::mutex> lock(m_mutexFlagsLive);
   std::vector<Ctf01dFlag> vResult;
-  long nCurrentTime = WsjcppCore::getCurrentTimeInMilliseconds() - m_nFlagTimeLiveInSec*1000;
+  long nCurrentTime = WsjcppCore::getCurrentTimeInMilliseconds();
   std::map<std::string,Ctf01dFlag>::iterator it;
   for (it = m_mapFlagsLive.begin(); it != m_mapFlagsLive.end(); it++) {
     Ctf01dFlag flag = it->second;

--- a/src/ctf01d/objects/ctf01d_scoreboard.h
+++ b/src/ctf01d/objects/ctf01d_scoreboard.h
@@ -53,8 +53,7 @@ public:
     int nGameStartInSec,
     int nGameEndInSec,
     int nGameCoffeeBreakStartInSec,
-    int nGameCoffeeBreakEndInSec,
-    int nFlagTimeLiveInSec
+    int nGameCoffeeBreakEndInSec
   );
 
   void setServiceStatus(const std::string &sTeamId, const std::string &sServiceId, const std::string &sStatus);
@@ -87,7 +86,6 @@ private:
   int m_nGameEndInSec;
   int m_nGameCoffeeBreakStartInSec;
   int m_nGameCoffeeBreakEndInSec;
-  int m_nFlagTimeLiveInSec;
   int m_nTeamCount;
 
   void sortPlaces(); // TODO merge this function with update costs


### PR DESCRIPTION
- Remove nFlagTimeLiveInSec from scoreboard, outdatedFlagsLive now compares against current time without offset
- Fix checker script permissions to only add execute bits instead of setting full 777