### PR TITLE
Add Ctf01dScoreboard::countFlagsLive()

### DIFF
--- a/src/ctf01d/objects/ctf01d_scoreboard.cpp
+++ b/src/ctf01d/objects/ctf01d_scoreboard.cpp
@@ -434,6 +434,10 @@ std::string Ctf01dScoreboard::serviceStatus(const std::string &sTeamId, const st
   return "";
 }
 
+int Ctf01dScoreboard::countFlagsLive() {
+  return m_alive_flags->count_alive_flags();
+}
+
 static bool sort_using_greater_than(double u, double v) {
   return u > v;
 }

--- a/src/ctf01d/objects/ctf01d_scoreboard.h
+++ b/src/ctf01d/objects/ctf01d_scoreboard.h
@@ -71,6 +71,8 @@ public:
   void updateScore(const std::string &sTeamId, const std::string &sServiceId);
   std::string serviceStatus(const std::string &sTeamId, const std::string &sServiceId);
 
+  int countFlagsLive();
+
   // std::string toString();
   const nlohmann::json &toJson();
 


### PR DESCRIPTION
Thin wrapper over IAliveFlags::count_alive_flags() so callers that already hold a scoreboard pointer (e.g. the upcoming Prometheus metrics endpoint) do not need to look up the IAliveFlags employ themselves.